### PR TITLE
feat: 로또 당첨 순위 Enum 및 from() 테스트 추가

### DIFF
--- a/src/main/java/lotto/domain/Rank.java
+++ b/src/main/java/lotto/domain/Rank.java
@@ -1,0 +1,38 @@
+package lotto.domain;
+
+import java.util.Arrays;
+
+public enum Rank {
+
+    FIRST(6, false, 2_000_000_000),
+    SECOND(5, true, 30_000_000),
+    THIRD(5, false, 1_500_000),
+    FOURTH(4, false, 50_000),
+    FIFTH(3, false, 5_000),
+    MISS(0, false, 0);
+
+    private final int matchCount;
+    private final boolean matchBonus;
+    private final int prize;
+
+    Rank(int matchCount, boolean matchBonus, int prize) {
+        this.matchCount = matchCount;
+        this.matchBonus = matchBonus;
+        this.prize = prize;
+    }
+
+    public static Rank from(int matchCount, boolean matchBonus) {
+        if (matchCount < 3) {
+            return MISS;
+        }
+
+        return Arrays.stream(values())
+                .filter(rank -> rank.matchCount == matchCount && rank.matchBonus == matchBonus)
+                .findFirst()
+                .orElse(MISS);
+    }
+
+    public int getPrize() {
+        return prize;
+    }
+}

--- a/src/test/java/lotto/domain/RankTest.java
+++ b/src/test/java/lotto/domain/RankTest.java
@@ -1,0 +1,24 @@
+package lotto.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class RankTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "6, false, FIRST",
+            "5, true, SECOND",
+            "5, false, THIRD",
+            "4, false, FOURTH",
+            "3, false, FIFTH",
+            "2, false, MISS",
+            "1, false, MISS",
+            "0, false, MISS"
+    })
+    void 일치_개수와_보너스_번호로_등수를_판별한다(int matchCount, boolean bonus, Rank expected) {
+        assertThat(Rank.from(matchCount, bonus)).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요
- [ ] 당첨 순위와 일치 개수, 보너스 여부, 상금 정보를 Enum으로 정의
- [ ] matchCount와 matchBonus 기준으로 순위를 반환하는 from() 구현
- [ ] Rank Enum의 from() 메서드에 대한 단위 테스트 작성 및 통과 확인


## 💬 참고 사항(선택)
> 
